### PR TITLE
remove status cehck from the automation

### DIFF
--- a/main.go
+++ b/main.go
@@ -166,12 +166,6 @@ func main() {
 					RequiredLinearHistory:         pulumi.Bool(protection.RequiredLinearHistory),
 					RequireSignedCommits:          pulumi.Bool(protection.RequireSignedCommits),
 					RequireConversationResolution: pulumi.Bool(protection.RequireConversationResolution),
-					RequiredStatusChecks: github.BranchProtectionRequiredStatusCheckArray{
-						&github.BranchProtectionRequiredStatusCheckArgs{
-							Strict:   pulumi.Bool(protection.RequireBranchesUpToDate),
-							Contexts: pulumi.ToStringArray(protection.StatusChecks),
-						},
-					},
 					RequiredPullRequestReviews: github.BranchProtectionRequiredPullRequestReviewArray{
 						&github.BranchProtectionRequiredPullRequestReviewArgs{
 							DismissStaleReviews:          pulumi.Bool(protection.DismissStaleReviews),


### PR DESCRIPTION
#### Summary
- remove status cehck from the automation
then the mantainers will have more freedom to change it

Related to: https://github.com/sigstore/community/issues/187

I still need to remove the config data and also remove this from the pulumi state.
I will do as soon this PR is approved and before merging it