### PR TITLE
Add RequireLastPushApproval

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ branchesProtection:
     requireConversationResolution: true|false # optional
     restrictDismissals: true|false # optional
     requireBranchesUpToDate: true|false # optional
+    requireLastPushApproval: true|false #optional
     statusChecks:
       - DCO # optional. The name of the status checks that you want to be required for a PR.
     pushRestrictions:

--- a/main.go
+++ b/main.go
@@ -179,6 +179,7 @@ func main() {
 							RequireCodeOwnerReviews:      pulumi.Bool(protection.RequireCodeOwnerReviews),
 							RequiredApprovingReviewCount: pulumi.Int(protection.RequiredApprovingReviewCount),
 							DismissalRestrictions:        pulumi.ToStringArray(dismissalRestrictionsID),
+							RequireLastPushApproval:      pulumi.Bool(protection.RequireLastPushApproval),
 						},
 					},
 					PushRestrictions: pulumi.ToStringArray(pushRestrictionsID),

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -87,6 +87,7 @@ type BranchProtection struct {
 	RequireConversationResolution bool     `yaml:"requireConversationResolution"`
 	RequireCodeOwnerReviews       bool     `yaml:"requireCodeOwnerReviews"`
 	RequiredApprovingReviewCount  int      `yaml:"requiredApprovingReviewCount"`
+	RequireLastPushApproval       bool     `yaml:"requireLastPushApproval"``
 	StatusChecks                  []string `yaml:"statusChecks"`
 	RequireBranchesUpToDate       bool     `yaml:"requireBranchesUpToDate"`
 	PushRestrictions              []string `yaml:"pushRestrictions"`


### PR DESCRIPTION
This will mitigate insider risk where a maintainer can go to any open PR, modify the contents, and approve and merge the PR. This is effectively self-approval and bypasses the minimum of 1 reviewer check, since the maintainer the entire PR without another review. This check will require that the PR approver be different than the author on the last commit.

See https://github.blog/changelog/2022-10-20-new-branch-protections-last-pusher-and-locked-branch/#require-approval-from-someone-other-than-the-last-pusher for more information

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
