### PR TITLE
Support custom roles

### DIFF
--- a/main.go
+++ b/main.go
@@ -34,6 +34,19 @@ func main() {
 			log.Fatalf("Failed to load config: %v\n", err)
 		}
 
+		// sync custom roles
+		for _, customRole := range p.Config.CustomRoles {
+			roleArgs := &github.OrganizationCustomRoleArgs{
+				BaseRole:    pulumi.String(customRole.BaseRole),
+				Description: pulumi.String(customRole.Description),
+				Permissions: pulumi.ToStringArray(customRole.Permissions),
+			}
+			_, err := github.NewOrganizationCustomRole(ctx, customRole.Name, roleArgs)
+			if err != nil {
+				return err
+			}
+		}
+
 		// sync users
 		for _, member := range p.Config.Users {
 			_, err := github.NewMembership(ctx, member.Username, &github.MembershipArgs{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -4,6 +4,7 @@ type Config struct {
 	Users        []User       `yaml:"users"`
 	Teams        []Team       `yaml:"teams"`
 	Repositories []Repository `yaml:"repositories"`
+	CustomRoles  []CustomRole `yaml:"repositoryRoles"`
 }
 
 type User struct {
@@ -94,4 +95,11 @@ type BranchProtection struct {
 	StatusChecks                  []string `yaml:"statusChecks"`
 	RequireBranchesUpToDate       bool     `yaml:"requireBranchesUpToDate"`
 	PushRestrictions              []string `yaml:"pushRestrictions"`
+}
+
+type CustomRole struct {
+	Name        string   `yaml:"name"`
+	BaseRole    string   `yaml:"baseRole"`
+	Description string   `yaml:"description"`
+	Permissions []string `yaml:"permissions"`
 }


### PR DESCRIPTION
root-signing-staging (and later root-signing) is planning to use a [custom role](https://docs.github.com/en/enterprise-cloud@latest/organizations/managing-user-access-to-your-organizations-repositories/managing-repository-roles/about-custom-repository-roles) for the online signing system.

Add support for creating a custom role in the org so that a role can be defined and assigned to sigstore-bot for those repositories.

--- 

Fixes #117