### PR TITLE
parser: Handle custom roles

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -4,7 +4,7 @@ type Config struct {
 	Users        []User       `yaml:"users"`
 	Teams        []Team       `yaml:"teams"`
 	Repositories []Repository `yaml:"repositories"`
-	CustomRoles  []CustomRole `yaml:"repositoryRoles"`
+	CustomRoles  []CustomRole `yaml:"customRoles"`
 }
 
 type User struct {

--- a/pkg/config/parser.go
+++ b/pkg/config/parser.go
@@ -33,6 +33,10 @@ func (p *Parser) Parse(reader io.Reader) error {
 		return fmt.Errorf("failed to parse yaml: %w", err)
 	}
 
+	if c.CustomRoles != nil {
+		p.Config.CustomRoles = append(p.Config.CustomRoles, c.CustomRoles...)
+	}
+
 	if c.Users != nil {
 		p.Config.Users = append(p.Config.Users, c.Users...)
 	}


### PR DESCRIPTION
Parser appends results from each unmarshalled yaml  separately for each toplevel yaml field: This was missing for customRoles in my earlier PR #117 .

* Append unmarshalled customRoles to config
* Also make the toplevel name uniformly "customRoles": no need to use two different names

This should fix the failure in https://github.com/sigstore/community/pull/395 (although I will have to change the field name there as well).