### PR TITLE
Support Pages uploads from workflows

### DIFF
--- a/main.go
+++ b/main.go
@@ -117,7 +117,14 @@ func main() {
 				WebCommitSignoffRequired: pulumi.Bool(repo.WebCommitSignoffRequired),
 			}
 
-			if repo.Pages.Branch != "" {
+			if repo.Pages.BuildType == "workflow" {
+				repoPages := &github.RepositoryPagesArgs{
+					BuildType: pulumi.String("workflow"),
+				}
+				if repo.Pages.CNAME != "" {
+					repoPages.Cname = pulumi.String(repo.Pages.CNAME)
+				}
+			} else if repo.Pages.Branch != "" {
 				repoPages := &github.RepositoryPagesArgs{}
 
 				source := &github.RepositoryPagesSourceArgs{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -57,9 +57,10 @@ type Repository struct {
 }
 
 type Pages struct {
-	CNAME  string `yaml:"cname"`
-	Branch string `yaml:"branch"`
-	Path   string `yaml:"path"`
+	CNAME     string `yaml:"cname"`
+	Branch    string `yaml:"branch"`
+	BuildType string `yaml:"buildType"`
+	Path      string `yaml:"path"`
 }
 
 type Template struct {


### PR DESCRIPTION
Pages has two build types "legacy" (which seems to be default) and "workflow". Support also the latter one.

* The intent is to allow the buildType field but not require it
* If buildType=="workflow", branch and path are not needed

Closes #121.