### PR TITLE
Support pull request bypassers per repository

### DIFF
--- a/main.go
+++ b/main.go
@@ -193,7 +193,7 @@ func main() {
 					dismissalRestrictionsID = append(dismissalRestrictionsID, team.NodeId)
 				}
 
-				var PullRequestBypassersID []string
+				var pullRequestBypassersID []string
 				for _, teamOrUser := range protection.PullRequestBypassers {
 					team, err := github.LookupTeam(ctx, &github.LookupTeamArgs{
 						Slug: strings.ToLower(strings.ReplaceAll(teamOrUser, " ", "-")),
@@ -203,9 +203,9 @@ func main() {
 						if err != nil {
 							return err
 						}
-						PullRequestBypassersID = append(PullRequestBypassersID, user.NodeId)
+						pullRequestBypassersID = append(pullRequestBypassersID, user.NodeId)
 					} else {
-						PullRequestBypassersID = append(PullRequestBypassersID, team.NodeId)
+						pullRequestBypassersID = append(pullRequestBypassersID, team.NodeId)
 					}
 				}
 
@@ -231,7 +231,7 @@ func main() {
 							RequireCodeOwnerReviews:      pulumi.Bool(protection.RequireCodeOwnerReviews),
 							RequiredApprovingReviewCount: pulumi.Int(protection.RequiredApprovingReviewCount),
 							DismissalRestrictions:        pulumi.ToStringArray(dismissalRestrictionsID),
-							PullRequestBypassers:         pulumi.ToStringArray(PullRequestBypassersID),
+							PullRequestBypassers:         pulumi.ToStringArray(pullRequestBypassersID),
 							RequireLastPushApproval:      pulumi.Bool(protection.RequireLastPushApproval),
 						},
 					},

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -86,6 +86,7 @@ type BranchProtection struct {
 	AllowsForcePushes             bool     `yaml:"allowsForcePushes"`
 	DismissStaleReviews           bool     `yaml:"dismissStaleReviews"`
 	DismissalRestrictions         []string `yaml:"dismissalRestrictions"`
+	PullRequestBypassers          []string `yaml:"pullRequestBypassers"`
 	RestrictDismissals            bool     `yaml:"restrictDismissals"`
 	RequiredLinearHistory         bool     `yaml:"requiredLinearHistory"`
 	RequireSignedCommits          bool     `yaml:"requireSignedCommits"`


### PR DESCRIPTION
This is equivalent to
  _Allow specified actors to bypass required pull requests_
in the GitHub UI.

I've earlier tried to achieve this by adding support for custom roles and defining a role with a bypass permission but that has not succeeded: this seems like it may be less complicated as it's a repository-specific list of users/teams.

-- 

There is one thing I'm uncertain of here: when I manually modify the _Allow specified actors to bypass required pull requests_ in the UI for root-signing-staging, `sigstore/sigstore-oncall` is already in the list somehow. Maybe that is some org setting? Am I now overwriting that setting for all repositories?

I suppose we will find out when I make a PR in sigstore/community and we see the pulumi preview...