### PR TITLE
bump go.mod to go1.24 and golangci-lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,4 +37,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@2226d7cb06a077cd73e56eedd38eecad18e5d837 # v6.5.0
         with:
-          version: v1.59
+          version: v1.64

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sigstore/github-sync
 
-go 1.22
+go 1.24
 
 require (
 	github.com/bmatcuk/doublestar/v3 v3.0.0


### PR DESCRIPTION


#### Summary
- bump go.mod to go1.24 and golangci-lint